### PR TITLE
Resolve preloadings in mappings

### DIFF
--- a/src/main/scala/com/metabolic/data/core/services/util/ConfigReaderService.scala
+++ b/src/main/scala/com/metabolic/data/core/services/util/ConfigReaderService.scala
@@ -72,14 +72,21 @@ class ConfigReaderService(implicit val region: Regions) {
 
   private def prepareConfig(params: Map[String, String]) = {
 
+    val preloadedConfig = preloadConfig()
+
     params
       .filter { kv =>
         kv._1.startsWith("dp.")
       }.map { kv =>
-        System.setProperty(kv._1, kv._2)
+        val value = if (preloadedConfig.contains(kv._2)) {
+          preloadedConfig(kv._2)
+        } else {
+          kv._2
+        }
+        System.setProperty(kv._1, value)
       }
 
-    preloadConfig()
+    preloadedConfig
       .map { kv =>
         System.setProperty(kv._1, kv._2)
       }

--- a/src/test/resources/run_map.conf
+++ b/src/test/resources/run_map.conf
@@ -1,3 +1,4 @@
 path = ${?raw_bucket}"/tmp"
 pathy = ${dp.raw_bucket}/tmp
+time = ${dp.time}
 

--- a/src/test/resources/run_variable.conf
+++ b/src/test/resources/run_variable.conf
@@ -1,2 +1,2 @@
 path = ${?raw_bucket}"/tmp"
-
+time = ${df.now}

--- a/src/test/scala/com/metabolic/data/mapper/services/ConfigReaderServiceTest.scala
+++ b/src/test/scala/com/metabolic/data/mapper/services/ConfigReaderServiceTest.scala
@@ -8,6 +8,8 @@ import com.metabolic.data.mapper.domain.ops.mapping.TupletIntervalMapping
 import com.metabolic.data.mapper.domain.ops.source.{DedupeSourceOp, FilterSourceOp, SQLOrder, SelectExpressionSourceOp}
 import org.scalatest.funsuite.AnyFunSuite
 
+import scala.util.matching.Regex
+
 class ConfigReaderServiceTest extends AnyFunSuite with RegionedTest  {
 
   val personHOCON =
@@ -145,17 +147,40 @@ class ConfigReaderServiceTest extends AnyFunSuite with RegionedTest  {
 
   }
 
+  test("ConfigReaderService resolves a preload ") {
+
+    val overrideConfig = new ConfigReaderService().getConfig("src/test/resources/run_variable.conf")
+    val datePattern: String = """\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"""
+
+    assert(overrideConfig.getString("time").matches(datePattern))
+  }
+
   test("ConfigReaderService resolves a variable in map ") {
 
     val args: Map[String, String] = Map(
       "dp.region" -> "eu-west-4",
-      "dp.raw_bucket" -> "s3://factorial-dl-rawy"
+      "dp.raw_bucket" -> "s3://factorial-dl-rawy",
+      "dp.time" -> "2021-01-01T00:00:00"
     )
 
     val overrideConfig = new ConfigReaderService().getConfig("src/test/resources/run_map.conf", args)
 
     assert(overrideConfig.getString("pathy") == "s3://factorial-dl-rawy/tmp")
 
+  }
+
+  test("ConfigReaderService resolves a preload in a map") {
+
+    val args: Map[String, String] = Map(
+      "dp.region" -> "eu-west-4",
+      "dp.raw_bucket" -> "s3://factorial-dl-rawy",
+      "dp.time" -> "df.now"
+    )
+
+    val overrideConfig = new ConfigReaderService().getConfig("src/test/resources/run_map.conf", args)
+    val datePattern: String = """\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"""
+
+    assert(overrideConfig.getString("time").matches(datePattern))
   }
 
   test("ConfigReaderService resolves mappings ") {


### PR DESCRIPTION
Currently, it is not possible to set a parameter to resolve to a mapping:

```
dp.from = df.now
```

It does not get translated to a real time. It remains as "df.now"

This translation is interesting for data recovery. We can parameterize prunning of bronze tables with default arguments, like

```
dp.from = df.start_of_today
dp.to = df.now
```

When we want to recover from a loss in some window of time, we can manually run the glue job manually in AWS glue, passing the boundaries of the window:

```
dp.from = "2023-07-27T09:34:00"
dp.to = "2023-07-28T10:04:00"
```