### PR TITLE
Update iceberg and actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download em_entrypoint
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: em_entrypoint
 
@@ -57,7 +57,7 @@ jobs:
           FILE: ./MapperEntrypoint.scala
 
       - name: Download jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: jar
 
@@ -81,7 +81,7 @@ jobs:
         uses: EthanSK/git-branch-name-action@v1
 
       - name: Download em_entrypoint
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: em_entrypoint
 
@@ -96,7 +96,7 @@ jobs:
           FILE: ./MapperEntrypoint.scala
 
       - name: Download jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: jar
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,13 @@ jobs:
         run: sbt assembly
 
       - name: Upload output jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jar
           path: target/scala-2.12/metabolic-core-assembly-SNAPSHOT.jar
 
       - name: Upload output entrypoint
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: em_entrypoint
           path: src/main/scala/MapperEntrypoint.scala

--- a/build.sbt
+++ b/build.sbt
@@ -7,16 +7,17 @@ scalaVersion := "2.12.17"
 /* Reusable versions */
 val sparkVersion = "3.3.2"
 val awsVersion = "1.12.682"
+val icebergVersion = "1.6.1"
 val testContainersVersion = "0.40.12"
 
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-sql-kafka-0-10" % sparkVersion,
-  "org.apache.kafka" % "kafka-clients" % "3.3.2",
+  "org.apache.kafka" % "kafka-clients" % sparkVersion,
 
   "io.delta" %% "delta-core" % "2.3.0",
-  "org.apache.iceberg" %% "iceberg-spark-runtime-3.3" % "1.6.1",
-  "org.apache.iceberg" % "iceberg-aws-bundle" % "1.6.1",
+  "org.apache.iceberg" %% "iceberg-spark-runtime-3.3" % icebergVersion,
+  "org.apache.iceberg" % "iceberg-aws-bundle" % icebergVersion,
 
 
   "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",


### PR DESCRIPTION
Artifact actions are deprecated as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/, so we update them  to V4.