### PR TITLE
Iceberg delete implementation

### DIFF
--- a/src/main/scala/com/metabolic/data/core/services/spark/writer/file/IcebergWriter.scala
+++ b/src/main/scala/com/metabolic/data/core/services/spark/writer/file/IcebergWriter.scala
@@ -106,7 +106,6 @@ class IcebergWriter(
           .outputMode("append")
           .trigger(Trigger.ProcessingTime(1, TimeUnit.MINUTES))
           .option("checkpointLocation", checkpointLocation)
-          .option("mergeSchema","true")
           .toTable(output_identifier)
 
       case WriteMode.Complete =>
@@ -116,7 +115,6 @@ class IcebergWriter(
           .outputMode("complete")
           .trigger(Trigger.ProcessingTime(1, TimeUnit.MINUTES))
           .option("checkpointLocation", checkpointLocation)
-          .option("mergeSchema","true")
           .toTable(output_identifier)
 
     }

--- a/src/test/scala/com/metabolic/data/core/services/spark/writer/IcebergWriterTest.scala
+++ b/src/test/scala/com/metabolic/data/core/services/spark/writer/IcebergWriterTest.scala
@@ -3,9 +3,7 @@ package com.metabolic.data.core.services.spark.writer
 import com.holdenkarau.spark.testing.{DataFrameSuiteBase, SharedSparkContext}
 import com.metabolic.data.core.services.spark.writer.file.IcebergWriter
 import com.metabolic.data.mapper.domain.io.{EngineMode, WriteMode}
-import org.apache.iceberg.expressions.False
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.scalatest.BeforeAndAfterAll
@@ -145,6 +143,7 @@ class IcebergWriterTest extends AnyFunSuite
     val iceberg = new IcebergWriter(fqn, wm, None, cpl)(spark)
 
     iceberg.write(inputDF, EngineMode.Batch)
+
     val exception = intercept[Exception] {
       iceberg.write(differentInputDF, EngineMode.Batch)
     }


### PR DESCRIPTION
We want users to be able to drop tables with purge, so data in s3 is removed when dropping a table in the catalog.