### PR TITLE
Fail when reading conf that doesn't exist

### DIFF
--- a/src/main/scala/com/metabolic/data/core/services/util/FileReaderService.scala
+++ b/src/main/scala/com/metabolic/data/core/services/util/FileReaderService.scala
@@ -47,8 +47,8 @@ class FileReaderService(implicit val region: Regions) extends Logging {
 
     } catch {
       case e: AmazonServiceException => {
-        logger.info(s"AmazonServiceException (likely AmazonS3Exception), ${e.getMessage} for key ${path}")
-        ""
+        logger.error(s"AmazonServiceException (likely AmazonS3Exception), ${e.getMessage} for key ${path}")
+        throw e
       }
     }
 


### PR DESCRIPTION
Elevate the exception when conf file doesnt exist and is reading from S3