### PR TITLE
Fix historical writes with Iceberg

### DIFF
--- a/src/main/scala/com/metabolic/data/mapper/app/MetabolicWriter.scala
+++ b/src/main/scala/com/metabolic/data/mapper/app/MetabolicWriter.scala
@@ -121,13 +121,13 @@ object MetabolicWriter extends Logging {
           case cols => Some(cols.distinct)
         }
 
-        val table.writeMode = if (historical) {
+        val writeMode = if (historical) {
           WriteMode.Overwrite
         } else {
           table.writeMode
         }
 
-        new IcebergWriter(table.catalog, table.writeMode, table.idColumnNames, checkpointPath, partitionColsOpt)
+        new IcebergWriter(table.catalog, writeMode, table.idColumnNames, checkpointPath, partitionColsOpt)
           .write(_df, mode)
 
       }


### PR DESCRIPTION
Unexpected behaviour due to bad variable substitution, fixed to always overwrite in historical iceberg sinks.